### PR TITLE
Fixed issue with router support on github pages

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -26,16 +26,18 @@ function App() {
         {/* <ScholarshipListCardGrid />
             <ScholarshipAsideCardGrid /> */}
           <Switch>
-            <Route exact path="/scholarship">
+          {/* <Route path={process.env.PUBLIC_URL + '/'}></Route> */}
+            <Route exact path={process.env.PUBLIC_URL + '/scholarship'}>
               {/* <Home /> */}
               <Scholarship />
             </Route>
-            <Route exact path="/scholarship-list">
+            <Route exact path={process.env.PUBLIC_URL + '/scholarship-list'}>
               {/* <Home /> */}
               <ScholarshipHeaderBlue />
               <ScholarshipList />
             </Route>
-            <Route exact path="/">
+            {/* <Route exact path={process.env.PUBLIC_URL + '/'}> */}
+            <Route path='/'>
               <Home />
             </Route>
           </Switch>

--- a/src/component/pages/Scholarship/ProgramCardGrid/ProgramCardGrid.js
+++ b/src/component/pages/Scholarship/ProgramCardGrid/ProgramCardGrid.js
@@ -11,17 +11,17 @@ const ProgramCardGrid = () => {
         <div className="programs">
           <div className="program-nav">
             <p className="program__text">Search scholarships by programs</p>
-            <Link to="./" className="btn btn-tab btn-secondary">
+            <Link to={process.env.PUBLIC_URL + '/'} className="btn btn-tab btn-secondary">
               Undergraduate
             </Link>
-            <Link to="./" className="btn btn-tab">
+            <Link to={process.env.PUBLIC_URL + '/'} className="btn btn-tab">
               Postgraduate
             </Link>
           </div>
           <div className="grid grid-cols-3">
             <ScholarshipCard></ScholarshipCard>
           </div>
-          <Link to="/scholarship-list" className="btn btn-large btn-primary btn-more">
+          <Link to={process.env.PUBLIC_URL + '/scholarship-list'} className="btn btn-large btn-primary btn-more">
             See more
           </Link>
         </div>

--- a/src/component/shared/Header/Header.js
+++ b/src/component/shared/Header/Header.js
@@ -15,42 +15,42 @@ export const Header = () => {
     return (
         <header className="schpg-container nav-hero-blend">
             <nav className="block block-center nav-container">
-                <Link to="/"><img className="logo" src={ logo } alt="" /></Link>
+                <Link to={process.env.PUBLIC_URL + '/'}><img className="logo" src={ logo } alt="" /></Link>
                 <ul className="nav-links">
                     <li className="nav-link">
-                        <Link to="/">Explore schools</Link>
+                        <Link to={process.env.PUBLIC_URL + '/'}>Explore schools</Link>
                     </li>
                     <li className="nav-link">
-                        <Link to="/">Compare schools</Link>
+                        <Link to={process.env.PUBLIC_URL + '/'}>Compare schools</Link>
                     </li>
                     <li className="nav-link">
-                        <Link className="hello" to="/scholarship">Find scholarship</Link>
+                        <Link className="hello" to={process.env.PUBLIC_URL + '/scholarship'}>Find scholarship</Link>
                     </li>
                     <li className="nav-link">
-                        <Link to="/">Career advisory</Link>
+                        <Link to={process.env.PUBLIC_URL + '/'}>Career advisory</Link>
                     </li>
                 </ul>
                 <ul className="nav-links">
                     <li className="nav-link">
-                        <Link to="/" className="nav-link-with-image">
+                        <Link to={process.env.PUBLIC_URL + '/'} className="nav-link-with-image">
                             <img className="svg-icon" src={ search } alt="search icon" />
                             Search
                         </Link>
                     </li>
                     <li className="nav-link">
-                        <Link to="/" className="nav-link-with-image">
+                        <Link to={process.env.PUBLIC_URL + '/'} className="nav-link-with-image">
                             <img className="svg-icon" src={ globe } alt="" />                         
                             Language
                         </Link>
                     </li>
                     <li className="nav-link">
-                        <Link to="/" className="nav-link-with-image">
+                        <Link to={process.env.PUBLIC_URL + '/'} className="nav-link-with-image">
                             <img className="svg-icon" src={ user } alt="" />                           
                             User
                         </Link>
                     </li>
                     <li className="nav-link">
-                        <Link to="/" className="nav-link-with-image">
+                        <Link to={process.env.PUBLIC_URL + '/'} className="nav-link-with-image">
                             <img className="svg-icon" src={ bookmark } alt="" />                           
                             Saved
                         </Link>
@@ -93,7 +93,7 @@ export const Header = () => {
                                 <option value="doctorate">Australia</option>
                             </select>
                         </div>
-                        <Link to="/" className="btn btn-small btn-primary btn-search">Search</Link>
+                        <Link to={process.env.PUBLIC_URL + '/'} className="btn btn-small btn-primary btn-search">Search</Link>
                     </form>
                 </div>
             </section>

--- a/src/component/shared/ScholarshipHeaderBlue/ScholarshipHeaderBlue.js
+++ b/src/component/shared/ScholarshipHeaderBlue/ScholarshipHeaderBlue.js
@@ -12,42 +12,42 @@ export const ScholarshipHeaderBlue = () => {
   return (
     <header className=".schpg-container hblue-schpg-container">
       <nav className="block block-center nav-container">
-        <Link to="/"><img className="logo" src={logo} alt="" /></Link>
+        <Link to={process.env.PUBLIC_URL + '/'}><img className="logo" src={logo} alt="" /></Link>
         <ul className="nav-links">
           <li className="nav-link">
-            <Link to="/">Explore schools</Link>
+            <Link to={process.env.PUBLIC_URL + '/'}>Explore schools</Link>
           </li>
           <li className="nav-link">
-            <Link to="/">Compare schools</Link>
+            <Link to={process.env.PUBLIC_URL + '/'}>Compare schools</Link>
           </li>
           <li className="nav-link">
-            <Link to="/scholarship">Find scholarship</Link>
+            <Link to={process.env.PUBLIC_URL + '/scholarship'}>Find scholarship</Link>
           </li>
           <li className="nav-link">
-            <Link to="/career-advisory">Career advisory</Link>
+            <Link to={process.env.PUBLIC_URL + '/career-advisory'}>Career advisory</Link>
           </li>
         </ul>
         <ul className="nav-links">
           <li className="nav-link">
-            <Link to="/" className="nav-link-with-image">
+            <Link to={process.env.PUBLIC_URL + '/'} className="nav-link-with-image">
               <img className="svg-icon" src={search} alt="search icon" />
               Search
             </Link>
           </li>
           <li className="nav-link">
-            <Link to="/" className="nav-link-with-image">
+            <Link to={process.env.PUBLIC_URL + '/'} className="nav-link-with-image">
               <img className="svg-icon" src={globe} alt="" />
               Language
             </Link>
           </li>
           <li className="nav-link">
-            <Link to="/" className="nav-link-with-image">
+            <Link to={process.env.PUBLIC_URL + '/'} className="nav-link-with-image">
               <img className="svg-icon" src={user} alt="" />
               User
             </Link>
           </li>
           <li className="nav-link">
-            <Link to="/" className="nav-link-with-image">
+            <Link to={process.env.PUBLIC_URL + '/'} className="nav-link-with-image">
               <img className="svg-icon" src={bookmark} alt="" />
               Saved
             </Link>


### PR DESCRIPTION
There was an issue with the router link implementation done on the former push. It appears as though GitHub pages doesn't support native react-router links. So, the router paths were modified, following [this resource ](https://github.com/facebook/create-react-app/issues/1765)

This has been implemented and should work hopefully.